### PR TITLE
Fix aspect ratio incorrectly inverted

### DIFF
--- a/search.go
+++ b/search.go
@@ -103,8 +103,8 @@ func (r Resolution) isValid() bool {
 
 //Ratio may be used to specify the aspect ratio of the search
 type Ratio struct {
-	Vertical   int64
-	Horizontal int64
+	Horizontal int
+	Vertical   int
 }
 
 func (r Ratio) String() string {

--- a/search.go
+++ b/search.go
@@ -108,7 +108,7 @@ type Ratio struct {
 }
 
 func (r Ratio) String() string {
-	return fmt.Sprintf("%vx%v", r.Vertical, r.Horizontal)
+	return fmt.Sprintf("%vx%v", r.Horizontal, r.Vertical)
 }
 
 func (r Ratio) isValid() bool {

--- a/search_test.go
+++ b/search_test.go
@@ -2,15 +2,29 @@ package wallhaven
 
 import "testing"
 
-// Ensure the aspect ratio respects the format required by the wallhaven API.
-// Horizontal comes first, then it's vertical.
-func TestQueryAspectRatio(t *testing.T) {
+func TestQueryDesignatedAspectRatio(t *testing.T) {
 	s := Search{
 		Ratios: []Ratio{
 			{
+				// Using designated struct members, so that their order aren't relevant.
 				Horizontal: 16,
 				Vertical:   9,
 			},
+		},
+	}
+
+	query := s.toQuery()
+	queryEncoded := query.Encode()
+
+	if queryEncoded != "ratios=16x9" {
+		t.Fail()
+	}
+}
+
+func TestQueryAspectRatio(t *testing.T) {
+	s := Search{
+		Ratios: []Ratio{
+			{16, 9}, // No struct designators, we ensure that Horizontal comes first, then it's vertical.
 		},
 	}
 

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,23 @@
+package wallhaven
+
+import "testing"
+
+// Ensure the aspect ratio respects the format required by the wallhaven API.
+// Horizontal comes first, then it's vertical.
+func TestQueryAspectRatio(t *testing.T) {
+	s := Search{
+		Ratios: []Ratio{
+			{
+				Horizontal: 16,
+				Vertical:   9,
+			},
+		},
+	}
+
+	query := s.toQuery()
+	queryEncoded := query.Encode()
+
+	if queryEncoded != "ratios=16x9" {
+		t.Fail()
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -1,8 +1,10 @@
 package wallhaven
 
+import "fmt"
+
 //GetTagInfo returns metadata regarding a single tag when given its int ID
 func GetTagInfo(t TagID) (*Tag, error) {
-	resp, err := get("/tag/" + string(t))
+	resp, err := get("/tag/" + fmt.Sprint(t))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This solve an issue where the aspect ratio sent to the wallhaven API does not match the format they expect to receive.

It's supposed to be the horizontal length, then the vertical length, separated by the 'x' character.
Multiple aspect ratios are comma separated and they seem to also support floating pointer numbers as string too.

The current implementation incorrectly inverted them (vertical then horizontal).

Cheers (: