### PR TITLE
No longer pollute stdout during searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 go-wallhaven
 cmd/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/.idea
 go-wallhaven
 cmd/**

--- a/http.go
+++ b/http.go
@@ -2,7 +2,6 @@ package wallhaven
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +14,6 @@ func processResponse(resp *http.Response, out interface{}) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s", byt)
 	resp.Body.Close()
 	return json.Unmarshal(byt, out)
 


### PR DESCRIPTION
Hello,

I'm using your library and you did an awesome job. :)

During my usage, I noticed processResponse is polluting stdout with debugging information.
This is good for an application but not so much so for a library.

I made a quick change to remove the offending line.

Cheers,
Alex