### PR TITLE
Fix pagination during search queries

### DIFF
--- a/search.go
+++ b/search.go
@@ -163,7 +163,7 @@ type Search struct {
 	Resolutions []Resolution
 	Ratios      []Ratio
 	Colors      []string //Colors is an array of hex colors represented as strings in #RRGGBB format
-	Page        int64
+	Page        int
 }
 
 func (s Search) toQuery() url.Values {
@@ -210,6 +210,9 @@ func (s Search) toQuery() url.Values {
 	}
 	if len(s.Colors) > 0 {
 		v.Add("colors", strings.Join([]string(s.Colors), ","))
+	}
+	if s.Page > 0 {
+		v.Add("page", strconv.Itoa(s.Page))
 	}
 	return v
 }

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,16 @@
+package wallhaven
+
+import "testing"
+
+func TestQueryPagination(t *testing.T) {
+	s := Search{
+		Page: 2,
+	}
+
+	query := s.toQuery()
+	queryEncoded := query.Encode()
+
+	if queryEncoded != "page=2" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Doing a search query and asking for specific pages didn't work, despite both the library API and wallhaven's API both supporting it.

Fixed the code to properly pass the parameter.